### PR TITLE
Accessibility service for Whatsapp name

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,11 @@ Outputs a cat fact from a [Cat Fact API](https://alexwohlbruck.github.io/cat-fac
 `/dad joke!curl(https://icanhazdadjoke.com/)`
 Outputs a random lame joke.
 
+## Accessibility Service (optional)
+
+kboard provides an accessibilty service which can be used to populate a person's name from Whatsapp conversations.
+
+This can be accessed with the keywords `$name`, `$fname` and `$lname`.
+
+This service is optional, and the keyboard is fully functional without it.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,19 @@
             </intent-filter>
         </service>
 
+        <service android:name=".KboardAccessibilityService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:label="Kboard Accessibility">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+
+        </service>
+
+
         <activity
             android:name=".PrefsActivity"
             android:label="@string/settings_name"

--- a/app/src/main/java/com/adgad/kboard/KCommands.java
+++ b/app/src/main/java/com/adgad/kboard/KCommands.java
@@ -498,7 +498,7 @@ public class KCommands {
                         commands = new String[1];
                         commands[0] = cmd;
                         int numberOfTimes = cmd.indexOf("e") > 0 ? Integer.parseInt(cmd.substring(0, cmd.indexOf("e"))) : 1;
-                        String parameter = cmd.substring(cmd.indexOf("(") + 1, cmd.lastIndexOf(")"));
+                        String parameter = replaceDollarWords(cmd.substring(cmd.indexOf("(") + 1, cmd.lastIndexOf(")")));
                         e(numberOfTimes, parameter);
                     } else {
                         commands = cmd.split(",");
@@ -539,20 +539,20 @@ public class KCommands {
     private String replaceDollarWords(String initial) {
         String newWord = initial;
         if(buffer != null) {
-            newWord = newWord.replaceAll("\\$0", buffer);
+            newWord = newWord.replace("$0", buffer);
         }
         if(KboardAccessibilityService.getCurrentWhatsappName() != null) {
             String fullName = KboardAccessibilityService.getCurrentWhatsappName();
             String[] names = fullName.split(" ");
 
             if(names.length > 1) {
-                newWord = newWord.replaceAll("\\$fname", names[0]);
-                newWord = newWord.replaceAll("\\$lname", names[1]);
+                newWord = newWord.replace("$fname", names[0]);
+                newWord = newWord.replace("$lname", names[1]);
             } else {
-                newWord = newWord.replaceAll("\\$fname", fullName);
+                newWord = newWord.replace("$fname", fullName);
             }
 
-            newWord = newWord.replaceAll("\\$name", KboardAccessibilityService.getCurrentWhatsappName());
+            newWord = newWord.replace("$name", KboardAccessibilityService.getCurrentWhatsappName());
         }
         return newWord;
     }

--- a/app/src/main/java/com/adgad/kboard/KCommands.java
+++ b/app/src/main/java/com/adgad/kboard/KCommands.java
@@ -222,11 +222,7 @@ public class KCommands {
     //insert text
     public void i(int n, String parameter) {
         for(int i=0;i<n;i++) {
-            if (buffer != null) {
-                commitText(parameter.replaceAll("\\$0", buffer));
-            } else {
-                commitText(parameter);
-            }
+                commitText(replaceDollarWords(parameter));
         }
 
     }
@@ -234,11 +230,7 @@ public class KCommands {
     //insert text raw (without autospace etc)
     public void iraw(int n, String parameter) {
         for(int i=0;i<n;i++) {
-            if (buffer != null) {
-                inputConnection.commitText(parameter.replaceAll("\\$0", buffer), 1);
-            } else {
                 inputConnection.commitText(parameter, 1);
-            }
         }
     }
 
@@ -292,24 +284,16 @@ public class KCommands {
     //make uppercase
     public void upper(int n, String parameter) {
         for(int i=0;i<n;i++) {
-            String lastBufferWord = buffer;
-            if (lastBufferWord != null) {
-                inputConnection.commitText(parameter.replaceAll("\\$0", lastBufferWord).toUpperCase(), 1);
-            } else {
                 inputConnection.commitText(parameter.toUpperCase(), 1);
-            }
         }
     }
 
     //make lowercase
     public void lower(int n, String parameter) {
         for(int i=0;i<n;i++) {
-            String lastBufferWord = buffer;
-            if (lastBufferWord != null) {
-                inputConnection.commitText(parameter.replaceAll("\\$0", lastBufferWord).toLowerCase(), 1);
-            } else {
+
                 inputConnection.commitText(parameter.toLowerCase(), 1);
-            }
+
         }
     }
 
@@ -457,7 +441,7 @@ public class KCommands {
         }
     }
 
-    public Uri getImageUri (Bitmap inImage) {
+    private Uri getImageUri (Bitmap inImage) {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         inImage.compress(Bitmap.CompressFormat.JPEG, 100, bytes);
         String path = MediaStore.Images.Media.insertImage(mIme.getContentResolver(), inImage, "Title", null);
@@ -525,7 +509,8 @@ public class KCommands {
                             String[] commandMethodParts = command.split("(\\((?!\\))|,|(?<!\\()\\))"); //split out parameter in brackets
                             if(commandMethodParts.length > 1) { //has parameter
                                 commandMethod = commandMethodParts[0];
-                                parameter = commandMethodParts[1].replaceAll("\\$0", buffer);
+                                parameter = replaceDollarWords(commandMethodParts[1]);
+
                             } else {
                                 commandMethod = commandMethodParts[0];
                             }
@@ -549,6 +534,27 @@ public class KCommands {
             }
         }).start();
 
+    }
+
+    private String replaceDollarWords(String initial) {
+        String newWord = initial;
+        if(buffer != null) {
+            newWord = newWord.replaceAll("\\$0", buffer);
+        }
+        if(KboardAccessibilityService.getCurrentWhatsappName() != null) {
+            String fullName = KboardAccessibilityService.getCurrentWhatsappName();
+            String[] names = fullName.split(" ");
+
+            if(names.length > 1) {
+                newWord = newWord.replaceAll("\\$fname", names[0]);
+                newWord = newWord.replaceAll("\\$lname", names[1]);
+            } else {
+                newWord = newWord.replaceAll("\\$fname", fullName);
+            }
+
+            newWord = newWord.replaceAll("\\$name", KboardAccessibilityService.getCurrentWhatsappName());
+        }
+        return newWord;
     }
 
     private void execute(String cmd, int n, String parameter) {

--- a/app/src/main/java/com/adgad/kboard/KboardAccessibilityService.java
+++ b/app/src/main/java/com/adgad/kboard/KboardAccessibilityService.java
@@ -1,0 +1,39 @@
+package com.adgad.kboard;
+
+
+import android.accessibilityservice.AccessibilityService;
+import android.util.Log;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+public class KboardAccessibilityService extends AccessibilityService {
+
+        private static String mWhatsappName;
+        private AccessibilityNodeInfo titleNode;
+
+        @Override
+        public void onAccessibilityEvent(AccessibilityEvent event) {
+                try {
+                        mWhatsappName = "";
+                        String packageName = event.getPackageName().toString();
+                        if (packageName.equals("com.whatsapp")) {
+                                titleNode = event.getSource().findAccessibilityNodeInfosByViewId("com.whatsapp:id/conversation_contact_name").get(0);
+                        }
+                        if(titleNode != null) {
+                                mWhatsappName = titleNode.getText().toString();
+                        }
+                } catch(Exception e) {
+                        e.printStackTrace();
+                }
+        }
+
+        @Override
+        public void onInterrupt() {
+        }
+
+        public static String getCurrentWhatsappName() {
+                return mWhatsappName;
+        }
+
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,5 +10,5 @@
     <string name="label_keyboard_key_next">Next</string>
     <string name="label_keyboard_key_enter">\u21b5</string>
     <string name="title_activity_macro_help">MacroHelpActivity</string>
-
+    <string name="accessibility_service_description">Kboard Accessibility - used for getting the current user name in chat apps</string>
 </resources>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,10 @@
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/accessibility_service_description"
+    android:packageNames="com.whatsapp"
+    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityFlags="flagDefault"
+    android:accessibilityFeedbackType="feedbackAllMask"
+    android:notificationTimeout="100"
+    android:canRetrieveWindowContent="true"
+    android:settingsActivity="com.example.android.accessibility.ServiceSettingsActivity"
+    />


### PR DESCRIPTION
Add a new Accessibility Service which is used to read a contact name specifically in Whatsapp (just because that's what I tend to use the most). This can be used in the keyboard with keywords `$fname`, `$lname`, and `$name`.